### PR TITLE
Add support for zub1cg_sbc (ZUBoard-1CG)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ CSTR=\033[1;32m /_\\VNET\033[0m
 #-=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-
 
 # Base Vitis Platforms
-PLATFORMS=' mz7010_som mz7020_som pz7010_fmc2 pz7015_fmc2 pz7020_fmc2 pz7030_fmc2 u96v2_sbc uz3eg_iocc uz3eg_pciec uz7ev_evcc '
+PLATFORMS=' mz7010_som mz7020_som pz7010_fmc2 pz7015_fmc2 pz7020_fmc2 pz7030_fmc2 u96v2_sbc uz3eg_iocc uz3eg_pciec uz7ev_evcc zub1cg_sbc'
 # Project Specific Vitis Platforms
 #PROJECTS=' u96v2_sbc_dualcam '
 PROJECTS=' '
@@ -163,6 +163,9 @@ uz3eg_pciec:
 uz7ev_evcc: 
 	@echo -e '${CSTR} Building Vitis Platform for UltraZed-EV with EV Carrier Card'
 	$(MAKE) -C pfm_def/uz7ev_evcc ${step}
+zub1cg_sbc:
+	@echo -e '${CSTR} Building Vitis Platform for ZUBoard 1CG Base"
+	$(MAKE) -C pfm_def/zub1cg_sbc ${step}
 clean: cleanall
 	@echo -e '${CSTR} Executed make cleanall instead'
 cleanall: 

--- a/pfm_def/zub1cg_sbc/Makefile
+++ b/pfm_def/zub1cg_sbc/Makefile
@@ -1,0 +1,79 @@
+# ----------------------------------------------------------------------------
+#
+#        ** **        **          **  ****      **  **********  ********** ®
+#       **   **        **        **   ** **     **  **              **
+#      **     **        **      **    **  **    **  **              **
+#     **       **        **    **     **   **   **  *********       **
+#    **         **        **  **      **    **  **  **              **
+#   **           **        ****       **     ** **  **              **
+#  **  .........  **        **        **      ****  **********      **
+#     ...........
+#                                     Reach Further™
+#
+# ----------------------------------------------------------------------------
+#
+#  This design is the property of Avnet.  Publication of this
+#  design is not authorized without written consent from Avnet.
+#
+#  Product information is available at:
+#     http://avnet.me/zuboard-1cg
+#
+#  Disclaimer:
+#     Avnet, Inc. makes no warranty for the use of this code or design.
+#     This code is provided  "As Is". Avnet, Inc assumes no responsibility for
+#     any errors, which may appear in this code, nor does it make a commitment
+#     to update the information contained herein. Avnet, Inc specifically
+#     disclaims any implied warranties of fitness for a particular purpose.
+#                      Copyright(c) 2022 Avnet, Inc.
+#                              All rights reserved.
+#
+# ----------------------------------------------------------------------------
+
+#-=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-
+# Get Environment Variables
+#-=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-
+
+PLNX_VER             = $(strip $(subst .,_, ${PETALINUX_VER}))
+PROJECT_ROOT_FOLDER  = $(shell pwd)
+BASENAME_FOLDER      = $(shell basename ${PROJECT_ROOT_FOLDER})
+
+#-=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-
+# Project Variables
+#-=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-
+#
+# Enter the    Project Name     (from HDL repository)
+#              Board Name       (from HDL repository, will become Platform Name)
+#              PLNX Proj name   (from PetaLinux Make Script)
+#              PLNX ROOTFS name (from PetaLinux Make Script)
+
+
+HDL_PROJECT_NAME                  := base
+HDL_BOARD_NAME                    := zub1cg_sbc
+PETALINUX_PROJECT_NAME            := ${HDL_PROJECT_NAME}
+PETALINUX_ROOTFS_NAME             := ${HDL_BOARD_NAME}
+
+VITIS_ARCHITECTURE                := psu_cortexa53
+VITIS_PROJECT_DESCRIPTION         := "ZUBoard 1CG Vitis platform based on the Single Board Computer image.  More information can be found at http://avnet.me/zuboard-1cg"
+
+# MPSoC     = aarch64-xilinx-linux
+# Zynq 7000 = cortexa9t2hf-neon-xilinx-linux-gnueabi
+SYSROOTTYPE                       := cortexa72-cortexa53-xilinx-linux
+
+#-=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-
+# Check for Environment Configuration
+#-=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-
+
+ifeq ($(PETALINUX_ROOTFS_NAME)_, $(PETALINUX_PROJECT_NAME))
+$(error -=-=-= /_\\VNET Build Environment _NOT_ Set, Please Setup Environment =-=-=-)
+else
+$(info /_\VNET  Build Environment Configured for ${PLNX_VER} and)
+$(info /_\VNET  ${PROJECT_ROOT_FOLDER} with)
+$(info /_\VNET  Basename ${BASENAME_FOLDER})
+endif
+
+#-=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-
+# Include Project Makefile
+#-=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-=-=-=-=-=--=-=-
+
+# generic Makefile
+include ../../projectMakefile.mk


### PR DESCRIPTION
Adds support for the zub1cg_sbc (ZUBoard-1CG) board to the build scripts for building the Vector Addition (`vadd`) sample application. 

_Other Relevant Pull Requests are:_

HDL Additions Required - https://github.com/Avnet/hdl/pull/41

**TESTING**
Built and tested the `vadd` application on the zub1cg_sbc board. Test Passed successfully. 

