### PR TITLE
Added missing vadd a.xclbin to sd-card image.

### DIFF
--- a/app/vadd/hw/Makefile
+++ b/app/vadd/hw/Makefile
@@ -99,7 +99,7 @@ binary_container_1.build/krnl_vadd.xo: ../src/krnl_vadd.cpp krnl_vadd-compile.cf
 	$(VPP) $(VPP_OPTS) --compile -I"$(<D)" --platform ${VITIS_PLATFORM_PATH} --config common-config.cfg --config krnl_vadd-compile.cfg -o"$@" "$<"
 
 binary_container_1.xclbin: $(BINARY_CONTAINER_1_OBJS) link.cfg common-config.cfg
-	-@echo $(VPP) $(VPP_OPTS) --link --platform ${VITIS_PLATFORM_PATH} --config common-config.cfg --config ink.cfg -o"$@" $(BINARY_CONTAINER_1_OBJS) > binary_container_1.xclbin.sh
+	-@echo $(VPP) $(VPP_OPTS) --link --platform ${VITIS_PLATFORM_PATH} --config common-config.cfg --config link.cfg -o"$@" $(BINARY_CONTAINER_1_OBJS) > binary_container_1.xclbin.sh
 	$(VPP) $(VPP_OPTS) --link --platform ${VITIS_PLATFORM_PATH} --config common-config.cfg --config link.cfg -o"$@" $(BINARY_CONTAINER_1_OBJS)
 
 #
@@ -113,10 +113,12 @@ src/vadd.o: ../src/vadd.cpp ../src/vadd.h
 $(HOST_EXE): $(HOST_OBJECTS)
 	$(HOST_CXX) -o "$@" $(+) $(LDFLAGS)
 	-@echo $(VPP) $(VPP_OPTS) --platform ${VITIS_PLATFORM_PATH} -p binary_container_1.xclbin \
+		-o a.xclbin \
 		--package.out_dir package \
 		--package.rootfs $(VITIS_PLATFORM_DIR)/sw/$(VITIS_PLATFORM)/PetaLinux/rootfs/rootfs.ext4 \
 		--package.sd_file $(HOST_EXE)
 	-@$(VPP) $(VPP_OPTS) --platform ${VITIS_PLATFORM_PATH} -p binary_container_1.xclbin \
+		-o a.xclbin \
 		--package.out_dir package \
 		--package.rootfs $(VITIS_PLATFORM_DIR)/sw/$(VITIS_PLATFORM)/PetaLinux/rootfs/rootfs.ext4 \
 		--package.sd_file $(HOST_EXE)

--- a/app/vadd/hw/package/create_sd_card_image.sh
+++ b/app/vadd/hw/package/create_sd_card_image.sh
@@ -20,7 +20,7 @@
 #        ----| image.ub
 #        ----| init.sh
 #        ----| platform_desc.txt
-#        ----| binary_container_1.xclbin
+#        ----| a.xclbin
 #        ----| vadd
 #        ----| rootfs.tar.gz
 #
@@ -82,12 +82,12 @@ BOOT_DIM=512
 FREELO="$( losetup -f)"
 
 RF_LIST=(\
-    sd_card/BOOT.BIN \ls 
+    sd_card/BOOT.BIN \
     sd_card/boot.scr \
     sd_card/image.ub \
     sd_card/init.sh \
     sd_card/platform_desc.txt  \
-    sd_card/binary_container_1.xclbin \
+    sd_card/a.xclbin \
     sd_card/vadd \
 )
 

--- a/projectMakefile.mk
+++ b/projectMakefile.mk
@@ -238,8 +238,11 @@ else
 	make -C ../../projects/${HDL_BOARD_NAME}_${HDL_PROJECT_NAME}_${PLNX_VER}_vadd/hw
 	@echo -e '${LGRN}***********************'
 	@echo -e '  ${CSTR}'
+	@echo -e ' To create SDCARD image:'
+	@echo -e '  $$ cd ./projects/${HDL_BOARD_NAME}_${HDL_PROJECT_NAME}_${PLNX_VER}_vadd/hw/package/'
+	@echo -e '  $$ sudo ./create_sd_card_image.sh'
 	@echo -e ' To write image to SDCARD:'
-	@echo -e '  $ sudo dd bs=4M if=./projects/${HDL_BOARD_NAME}_${HDL_PROJECT_NAME}_${PLNX_VER}/hw/package/sd_card.img of=/dev/sd{x} status=progress conv=fsync'
+	@echo -e '  $$ sudo dd bs=4M if=./projects/${HDL_BOARD_NAME}_${HDL_PROJECT_NAME}_${PLNX_VER}_vadd/hw/package/sd_card.img of=/dev/sd{x} status=progress conv=fsync'
 	@echo -e ' Where {x} is a smaller case letter that specifies the device of your SD card'
 	@echo -e '   Note: use df -h to determine which device corresponds to your SD card'
 	@echo -e '${LGRN}***********************${NC}'


### PR DESCRIPTION
I've created a dev-2024.1 branch from the 2023.2 branch to do this PR into.

Added missing vadd a.xclbin to sd-card image.

The makefile creates 2 xclbin files, first it creates binary_container_1.xclbin and then in a second step it creates the package with the a.xclbin file.  I've updated the commands to make it more explicit where the "a.xclbin" is created instead of relying on it use the "a.xclbin" name by default.

Updated sd-card image instructions at end of build to indicate to user to run the create_sd_card_image.sh script and some minor corrections of paths.